### PR TITLE
2026-06 文宣標題移除「報名表」字樣

### DIFF
--- a/dist/events/2026-06-lev1.html
+++ b/dist/events/2026-06-lev1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>【從心出發】2026夏季Playback初階工作坊報名表</title>
+<title>【從心出發】2026夏季Playback初階工作坊</title>
 <meta name="description" content="2026夏季Playback即興劇場初階工作坊，6/14、6/21兩堂課，台北劍潭。從暖身、聆聽到共創呈現，給自己一個自在表達的空間。">
 <style>
   :root {
@@ -304,7 +304,7 @@
 <header class="hero">
   <img class="hero-img" src="../img/炷光2.png" alt="從心出發 Playback 工作坊">
   <span class="kicker">PLAYBACK THEATRE</span>
-  <h1>【從心出發】<br>2026夏季Playback初階工作坊報名表</h1>
+  <h1>【從心出發】<br>2026夏季Playback初階工作坊</h1>
   <div class="lead">
     <span>🌿 你是否也想在日常之外，給自己一個時間和空間，</span>
     <span>自在地表達自己、聆聽別人？</span>

--- a/public/events/2026-06-lev1.html
+++ b/public/events/2026-06-lev1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>【從心出發】2026夏季Playback初階工作坊報名表</title>
+<title>【從心出發】2026夏季Playback初階工作坊</title>
 <meta name="description" content="2026夏季Playback即興劇場初階工作坊，6/14、6/21兩堂課，台北劍潭。從暖身、聆聽到共創呈現，給自己一個自在表達的空間。">
 <style>
   :root {
@@ -304,7 +304,7 @@
 <header class="hero">
   <img class="hero-img" src="../img/炷光2.png" alt="從心出發 Playback 工作坊">
   <span class="kicker">PLAYBACK THEATRE</span>
-  <h1>【從心出發】<br>2026夏季Playback初階工作坊報名表</h1>
+  <h1>【從心出發】<br>2026夏季Playback初階工作坊</h1>
   <div class="lead">
     <span>🌿 你是否也想在日常之外，給自己一個時間和空間，</span>
     <span>自在地表達自己、聆聽別人？</span>


### PR DESCRIPTION
## Summary
- 將 `2026-06-lev1.html` 的 `<h1>` 大標題與 `<title>` 從「2026夏季Playback初階工作坊報名表」改為「2026夏季Playback初階工作坊」
- 文宣本身不應稱為「報名表」，實際報名表是頁面下方的連結
- public/ 與 dist/ 兩份同步更新

## Test plan
- [x] 開啟 `/events/2026-06-lev1.html`，確認瀏覽器分頁標題與頁面大標題皆已移除「報名表」字樣
- [x] 確認頁面下方「前往報名表」按鈕連結仍可正常開啟報名表單

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB8oL1JEgszHQca9yA5ESF)_